### PR TITLE
Update services.yml

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -49,6 +49,7 @@ services:
       - "@translator"
   huh.api.manager.resource:
     class: HeimrichHannot\ApiBundle\Manager\ApiResourceManager
+    public: true
     arguments:
       - "@contao.framework"
   huh.api.resource.default:


### PR DESCRIPTION
Remove error after installing the bundle in Contao 4.7.5: "The "huh.api.manager.resource" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead."