### PR TITLE
do not always set locale

### DIFF
--- a/src/Security/UsernamePasswordAuthenticator.php
+++ b/src/Security/UsernamePasswordAuthenticator.php
@@ -22,7 +22,9 @@ class UsernamePasswordAuthenticator extends AbstractGuardAuthenticator
      */
     public function getCredentials(Request $request)
     {
-        $this->translator->setLocale($request->getPreferredLanguage());
+        if (null !== ($locale = $request->getPreferredLanguage())) {
+            $this->translator->setLocale($locale);
+        }
 
         if ('POST' !== $request->getMethod()) {
             throw new AuthenticationException($this->translator->trans('huh.api.exception.auth.post_method_only'));


### PR DESCRIPTION
If a request does not send an `Accept-Language` request header (which is usually the case for API requests) there will currently be an error:

```
TypeError:
Argument 1 passed to Symfony\Component\Translation\DataCollectorTranslator::setLocale() must be of the type string, null given, called in /vendor/contao/core-bundle/src/Translation/DataCollectorTranslator.php on line 63

  at vendor/symfony/translation/DataCollectorTranslator.php:57
  at Symfony\Component\Translation\DataCollectorTranslator->setLocale(null)
     (vendor/contao/core-bundle/src/Translation/DataCollectorTranslator.php:63)
  at Contao\CoreBundle\Translation\DataCollectorTranslator->setLocale(null)
     (vendor/contao/core-bundle/src/Translation/Translator.php:79)
  at Contao\CoreBundle\Translation\Translator->setLocale(null)
     (vendor/heimrichhannot/contao-api-bundle/src/Security/UsernamePasswordAuthenticator.php:25)
```

This PR fixes that by only setting the locale if a language can be determined from the request. Otherwise the translator will use its default (English by default).